### PR TITLE
Allow `null` values in objects

### DIFF
--- a/propex.js
+++ b/propex.js
@@ -49,13 +49,13 @@ Propex.prototype = {
 };
 function examine(key, item,  property, events, context){
 	var subs = property.subproperties;
-	if(item == undefined || (subs && typeMismatch(subs.isArray, item))) {
+	if(item === undefined || (subs && typeMismatch(subs.isArray, item))) {
 		if(!property.isOptional && events.missing)
 			return events.missing(property, key, context);
 		return;
 	}
 
-	if(subs) {
+	if(subs && item) {
 		var subContext = context;
 		if(events.objectStart)
 			subContext = events.objectStart(property, key, item, context);


### PR DESCRIPTION
I'm not sure if stripping null is intended in the first place, but I
feel it's pretty weird. We're using propex to validate our
incoming POST data, so the previous behaviour is causing all "nulls" to
be dropped.

Edit: I'm really not sure about my fix, I don't fully grasp all the edge cases propex tries to handle. Feel free to point me in the right direction if you think this isn't a proper fix.
